### PR TITLE
ci: add cross-platform release workflow + AUR install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,13 @@ jobs:
             ext: .exe
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
@@ -75,7 +75,7 @@ jobs:
           echo "BIN_NAME=$OUT" >> "$GITHUB_ENV"
 
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bleamd-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ${{ env.BIN_NAME }}
@@ -91,7 +91,7 @@ jobs:
       contents: write
     steps:
       - name: download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -100,7 +100,7 @@ jobs:
         run: ls -lhR dist
 
       - name: publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: dist/bleamd-*
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+            ext: .exe
+          - goos: windows
+            goarch: arm64
+            ext: .exe
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: derive version metadata
+        id: version
+        shell: bash
+        run: |
+          GIT_COMMIT=$(git rev-list -1 HEAD)
+          GIT_LAST_TAG=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
+          GIT_EXACT_TAG=$(git name-rev --name-only --tags HEAD 2>/dev/null || echo "undefined")
+          echo "git_commit=$GIT_COMMIT"     >> "$GITHUB_OUTPUT"
+          echo "git_last_tag=$GIT_LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "git_exact_tag=$GIT_EXACT_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        shell: bash
+        run: |
+          OUT="bleamd-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
+          go build \
+            -trimpath \
+            -ldflags "-s -w \
+              -X main.GitCommit=${{ steps.version.outputs.git_commit }} \
+              -X main.GitLastTag=${{ steps.version.outputs.git_last_tag }} \
+              -X main.GitExactTag=${{ steps.version.outputs.git_exact_tag }}" \
+            -o "$OUT" .
+          ls -lh "$OUT"
+          echo "BIN_NAME=$OUT" >> "$GITHUB_ENV"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bleamd-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ env.BIN_NAME }}
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: list assets
+        run: ls -lhR dist
+
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/bleamd-*
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ A powerful standalone Markdown renderer for the terminal with advanced search, h
 ### 📦 Binary Release
 Download a [pre-compiled binary](https://github.com/guttermonk/bleamd/releases/latest) for your platform.
 
+Available targets:
+
+| OS | Architecture | Asset |
+|----|--------------|-------|
+| Linux | x86_64 | `bleamd-linux-amd64` |
+| Linux | aarch64 (ARM64) | `bleamd-linux-arm64` |
+| macOS | Intel (x86_64) | `bleamd-darwin-amd64` |
+| macOS | Apple Silicon (ARM64) | `bleamd-darwin-arm64` |
+| Windows | x86_64 | `bleamd-windows-amd64.exe` |
+| Windows | ARM64 | `bleamd-windows-arm64.exe` |
+
+After download, mark executable (`chmod +x bleamd-linux-amd64`) and move into your `$PATH` (`/usr/local/bin/bleamd`).
+
+### 🐧 Arch Linux (AUR)
+
+Install from source via the [`bleamd-git`](https://aur.archlinux.org/packages/bleamd-git) AUR package:
+
+```bash
+# Using yay
+yay -S bleamd-git
+
+# Using paru
+paru -S bleamd-git
+
+# Manual
+git clone https://aur.archlinux.org/bleamd-git.git
+cd bleamd-git
+makepkg -si
+```
+
+> A binary AUR package (`bleamd-bin`) tracking the GitHub releases produced by this workflow is planned once the first tagged release ships.
+
 ### ❄️ NixOS / Nix
 ```bash
 # Run directly


### PR DESCRIPTION
## Summary

Add a GitHub Actions release workflow that builds `bleamd` for six OS/arch combinations on every push and pull request, and publishes a GitHub Release with the prebuilt binaries on every `v*` tag. Also documents the new release targets and adds an Arch Linux install section.

This replaces the legacy `.travis.yml` (Go 1.12, broken since the deploy provider's API key was bound to the old repo owner) for binary distribution. The Travis file is left untouched in this PR — feel free to delete it in a follow-up if you no longer use Travis at all.

## Three logical commits

1. **`ci: add release workflow with matrix builder for 6 platforms`**
   - New `.github/workflows/release.yml`.
   - Matrix builds on `ubuntu-latest` (pure-Go cross-compile, no native runners needed):
     - `linux/amd64`, `linux/arm64`
     - `darwin/amd64`, `darwin/arm64`
     - `windows/amd64`, `windows/arm64`
   - Triggers:
     - `push` to `main` and `pull_request` targeting `main` → matrix build, upload artifacts only (sanity check).
     - `push tags: ['v*']` → matrix build + publish a GitHub Release with the six binaries attached via `softprops/action-gh-release`.
   - Build flags: `CGO_ENABLED=0`, `-trimpath`, `-ldflags '-s -w -X main.GitCommit=… -X main.GitLastTag=… -X main.GitExactTag=…'`.
   - Binary naming: `bleamd-{os}-{arch}[.exe]` (stable across versions; easy for install scripts).
   - Tags containing `-` (e.g. `v1.0.0-rc1`) are auto-marked as prereleases.

2. **`docs: list binary release targets and add Arch Linux install section`**
   - README now lists the six prebuilt binaries with a short post-download note (`chmod +x`, move into `\$PATH`).
   - New "Arch Linux (AUR)" section pointing at the existing [`bleamd-git`](https://aur.archlinux.org/packages/bleamd-git) package, with `yay`, `paru`, and manual `makepkg` snippets.
   - Notes that a binary AUR package (`bleamd-bin`) tracking these GitHub releases is planned once the first tagged release ships.

3. **`ci: pin GitHub Actions to commit SHAs`**
   - Every third-party action is pinned to the commit SHA of its latest stable semver release published at least 7 days before this PR was opened. Comments record the human-readable version next to the SHA.
   - Each major-version bump was reviewed against our usage; no input or output schema changes affect this workflow.

## Verification on my fork

The whole pipeline was exercised end-to-end on [`gurukulkarni/bleamd`](https://github.com/gurukulkarni/bleamd) before opening this PR:

| Test | Result |
|------|--------|
| PR build matrix (6 platforms) | ✅ all green |
| Local cross-compile of all 6 GOOS/GOARCH combos | ✅ verified `file` output for each |
| `go test ./...` and `go vet ./...` | ✅ pass |
| Tagged prerelease (`v0.0.2-test`) → full publish path | ✅ all 6 binaries attached to GitHub Release |
| `softprops/action-gh-release` prerelease detection (`-` in tag) | ✅ marked prerelease |
| Test releases cleaned up (no leftover assets on the fork) | ✅ |

## Test plan

- [ ] On merge: `push` to `main` triggers a sanity matrix build (no release).
- [ ] When you cut a real tag (`v0.1.0`, etc.), the same matrix runs and a GitHub Release is created with the six binaries attached.
- [ ] Existing tests + vet stay green.

## Notes / not in scope

- The repo currently sets `go 1.23.0` in `go.mod`. The workflow uses `go-version-file: go.mod` + `check-latest: true`, so CI floats on the latest 1.23.x patch. Bumping to a newer Go major (e.g. 1.26) would be a separate, project-level decision.
- Once the first real tag publishes binaries, you can ship a companion `bleamd-bin` AUR package that downloads from the GitHub Release — happy to follow up with a PR adding `PKGBUILD` notes if useful.